### PR TITLE
Fix logout redirect to root

### DIFF
--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -48,6 +48,6 @@ export const logout = () => {
   localStorage.removeItem("refresh_token");
 
   if (typeof window !== "undefined") {
-    window.location.href = "/login";
+    window.location.href = "/";
   }
 };


### PR DESCRIPTION
## Summary
- adjust logout redirect in `frontend/src/auth.js`

## Testing
- `npm test -- --watchAll=false` *(fails: react-app-rewired not found)*