### PR TITLE
Add unit tests for token expiration check

### DIFF
--- a/frontend/src/__tests__/auth.test.js
+++ b/frontend/src/__tests__/auth.test.js
@@ -1,0 +1,21 @@
+import { isTokenExpired } from "../auth";
+
+const createToken = (exp) => {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  return `${header}.${payload}.signature`;
+};
+
+describe("isTokenExpired", () => {
+  it("returns false for a token with a future expiration", () => {
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const token = createToken(exp);
+    expect(isTokenExpired(token)).toBe(false);
+  });
+
+  it("returns true for a token with a past expiration", () => {
+    const exp = Math.floor(Date.now() / 1000) - 60;
+    const token = createToken(exp);
+    expect(isTokenExpired(token)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for `isTokenExpired`

## Testing
- `npm test -- --watchAll=false` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff709273c8323aebeba39e0f289d5